### PR TITLE
fixed bottle uneeded deprecation

### DIFF
--- a/Formula/yt-dlp.rb
+++ b/Formula/yt-dlp.rb
@@ -7,8 +7,6 @@ class YtDlp < Formula
   sha256 "cc96211e8e55ebbb48d2e6609c0d0942507eb5471b2ce74e38f7b95f8d70a4e7"
   license "Unlicense"
 
-  bottle :unneeded
-
   depends_on "python@3.9"
 
   def install


### PR DESCRIPTION
Removed **bottle :unneeded** from Homebrew Formula per this error message:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the yt-dlp/taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/yt-dlp/homebrew-taps/Formula/yt-dlp.rb:10
```