### PR TITLE
increase readability of dependency links

### DIFF
--- a/Formula/yt-dlp.rb
+++ b/Formula/yt-dlp.rb
@@ -10,27 +10,27 @@ class YtDlp < Formula
   depends_on "python@3.9"
 
   resource "Brotli" do
-    url "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip"
+    url "https://files.pythonhosted.org/packages/source/B/Brotli/Brotli-1.0.9.zip"
     sha256 "4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"
   end
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/cc/85/319a8a684e8ac6d87a1193090e06b6bbb302717496380e225ee10487c888/certifi-2022.6.15.tar.gz"
+    url "https://files.pythonhosted.org/packages/source/c/certifi/certifi-2022.6.15.tar.gz"
     sha256 "84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"
   end
 
   resource "mutagen" do
-    url "https://files.pythonhosted.org/packages/f3/d9/2232a4cb9a98e2d2501f7e58d193bc49c956ef23756d7423ba1bd87e386d/mutagen-1.45.1.tar.gz"
+    url "https://files.pythonhosted.org/packages/source/m/mutagen/mutagen-1.45.1.tar.gz"
     sha256 "6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
   end
 
   resource "pycryptodomex" do
-    url "https://files.pythonhosted.org/packages/52/0d/6cc95a83f6961a1ca041798d222240890af79b381e97eda3b9b538dba16f/pycryptodomex-3.15.0.tar.gz"
+    url "https://files.pythonhosted.org/packages/source/p/pycryptodomex/pycryptodomex-3.15.0.tar.gz"
     sha256 "7341f1bb2dadb0d1a0047f34c3a58208a92423cdbd3244d998e4b28df5eac0ed"
   end
 
   resource "websockets" do
-    url "https://files.pythonhosted.org/packages/f8/a3/622d9acbfb9a71144b5d7609906bc648c62e3ca5fdbb1c8cca222949d82c/websockets-10.3.tar.gz"
+    url "https://files.pythonhosted.org/packages/source/w/websockets/websockets-10.3.tar.gz"
     sha256 "fc06cc8073c8e87072138ba1e431300e2d408f054b27047d047b549455066ff4"
   end
 


### PR DESCRIPTION
This will make it easier to manually update the dependency links, or perhaps even to automate it.

NOTE: I didn't apply the change to the yt-dlp link, because that one is automatically updated by Github actions. Perhaps the Github action could be updated now though, but I haven't actually looked at that part of the Github action workflow yet🤣

Before this gets merged someone should test it works, because I'm not sure how brew handles redirects