### PR TITLE
update python dependency from 3.9 to 3.10

### DIFF
--- a/Formula/yt-dlp.rb
+++ b/Formula/yt-dlp.rb
@@ -7,7 +7,7 @@ class YtDlp < Formula
   sha256 "5fbfac72fd035d11bc2693e5d1cd6933b1bc0712f742f5082a261703810bb5c9"
   license "Unlicense"
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   resource "Brotli" do
     url "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip"


### PR DESCRIPTION
I'm not sure what the effects of this will be (eg: compatibility), but https://github.com/Homebrew/homebrew-core/blob/master/Formula/yt-dlp.rb#L24 currently uses python 3.10

cc @Lesmiscore